### PR TITLE
Updated SDK VERSION 0695 to 0700 for Java SDK

### DIFF
--- a/kount-ris-sdk/src/main/java/com/kount/ris/Request.java
+++ b/kount-ris-sdk/src/main/java/com/kount/ris/Request.java
@@ -51,7 +51,7 @@ public abstract class Request {
 	 * @throws RisException 
 	 */
 	public Request() {
-		setVersion("0695");
+		setVersion("0700");
 		setKhashPaymentEncoding(true);
 		params.put("SDK", "JAVA");
 	}

--- a/kount-ris-sdk/src/test/java/com/kount/ris/util/Utilities.java
+++ b/kount-ris-sdk/src/test/java/com/kount/ris/util/Utilities.java
@@ -38,7 +38,7 @@ public class Utilities {
 			.setIpAddress("131.206.45.21")
 			.setCart(Collections.singletonList(cartItem0))
 
-			.setVersion("0695")
+			.setVersion("0700")
 			.setMerchantId(merchantId)
 			.setPayment(payment)
 			.setSessionId(sessionId)

--- a/sdk-integration-tests/src/main/java/com/kount/ris/util/Utilities.java
+++ b/sdk-integration-tests/src/main/java/com/kount/ris/util/Utilities.java
@@ -41,7 +41,7 @@ public final class Utilities {
 			.setIpAddress("131.206.45.21")
 			.setCart(Collections.singletonList(cartItem0))
 
-			.setVersion("0695")
+			.setVersion("0700")
 			.setMerchantId(merchantId)
 			.setPayment(payment)
 			.setSessionId(sessionId)

--- a/sdk-integration-tests/src/test/java/com/kount/ris/TestRisTestSuite.java
+++ b/sdk-integration-tests/src/test/java/com/kount/ris/TestRisTestSuite.java
@@ -253,7 +253,7 @@ public class TestRisTestSuite {
 		
 		Update update = new Update();
 		update.setMode(UpdateMode.NO_RESPONSE);
-		update.setVersion("0695");
+		update.setVersion("0700");
 		update.setTransactionId(transactionId);
 		update.setMerchantId(MERCHANT_ID);
 		update.setSessionId(sessionId);
@@ -292,7 +292,7 @@ public class TestRisTestSuite {
 		
 		Update update = new Update();
 		update.setMode(UpdateMode.WITH_RESPONSE);
-		update.setVersion("0695");
+		update.setVersion("0700");
 		update.setMerchantId(MERCHANT_ID);
 		update.setTransactionId(transactionId);
 		update.setSessionId(sessionId);


### PR DESCRIPTION
Updated default SDK version '0695' to '0700' for Java SDK (all code).