### PR TITLE
Swap int to long for numeric values

### DIFF
--- a/kount-ris-sdk/src/main/java/com/kount/ris/Inquiry.java
+++ b/kount-ris-sdk/src/main/java/com/kount/ris/Inquiry.java
@@ -36,10 +36,10 @@ public class Inquiry extends Request {
 	 * Set cash amount of any feasible goods.
 	 * 
 	 * @param cash
-	 *            int Cash amount of any feasible goods
+	 *            long Cash amount of any feasible goods
 	 * @return this
 	 */
-	public Inquiry setCash(int cash) {
+	public Inquiry setCash(long cash) {
 		this.params.put("CASH", String.valueOf(cash));
 		return this;
 	}
@@ -133,7 +133,7 @@ public class Inquiry extends Request {
 	 *            Transaction amount in lowest possible denomination of given currency
 	 * @return this
 	 */
-	public Inquiry setTotal(int total) {
+	public Inquiry setTotal(long total) {
 		this.params.put("TOTL", String.valueOf(total));
 		return this;
 	}


### PR DESCRIPTION
The Kount API supports passing up to 15 numeric characters for both TOTL and CASH

https://kount.github.io/docs/ris-data-submission/

The API supports numbers up to 999999999999999, but `int` only supports numbers up to 2147483647.
These fields should be represented as `long` rather than `int`.